### PR TITLE
Add extra dependencies for LangChain features

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,8 @@ beautifulsoup4
 
 pytest
 httpx<0.25
+psycopg
+ollama
+langchain-postgres
+langchain-community
+langchain-ollama


### PR DESCRIPTION
## Summary
- extend `requirements.txt` with psycopg, ollama, and LangChain related packages

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic.json_schema')*

------
https://chatgpt.com/codex/tasks/task_e_68408127dc90832db75ddd958934d235